### PR TITLE
use sqared eccentricity for ellipse calculation

### DIFF
--- a/flyingcircus_numeric/base.py
+++ b/flyingcircus_numeric/base.py
@@ -7911,12 +7911,12 @@ def angles_in_ellipse(
         rot_offset = np.pi / 2.0
     angles = 2 * np.pi * np.arange(num) / num
     if a != b:
-        eSq = 1.0 - b ** 2.0 / a ** 2.0
-        tot_size = sp.special.ellipeinc(2.0 * np.pi, eSq)
+        e2 = 1.0 - b ** 2.0 / a ** 2.0
+        tot_size = sp.special.ellipeinc(2.0 * np.pi, e2)
         arc_size = tot_size / num
-        arcs = np.arange(num) * arc_size + sp.special.ellipeinc(offset, eSq)
+        arcs = np.arange(num) * arc_size + sp.special.ellipeinc(offset, e2)
         res = sp.optimize.root(
-            lambda x: (sp.special.ellipeinc(x, eSq) - arcs), angles)
+            lambda x: (sp.special.ellipeinc(x, e2) - arcs), angles)
         angles = res.x
     return angles + rot_offset
 

--- a/flyingcircus_numeric/base.py
+++ b/flyingcircus_numeric/base.py
@@ -7911,12 +7911,12 @@ def angles_in_ellipse(
         rot_offset = np.pi / 2.0
     angles = 2 * np.pi * np.arange(num) / num
     if a != b:
-        e = (1.0 - b ** 2.0 / a ** 2.0) ** 0.5
-        tot_size = sp.special.ellipeinc(2.0 * np.pi, e)
+        eSq = 1.0 - b ** 2.0 / a ** 2.0
+        tot_size = sp.special.ellipeinc(2.0 * np.pi, eSq)
         arc_size = tot_size / num
-        arcs = np.arange(num) * arc_size + sp.special.ellipeinc(offset, e)
+        arcs = np.arange(num) * arc_size + sp.special.ellipeinc(offset, eSq)
         res = sp.optimize.root(
-            lambda x: (sp.special.ellipeinc(x, e) - arcs), angles)
+            lambda x: (sp.special.ellipeinc(x, eSq) - arcs), angles)
         angles = res.x
     return angles + rot_offset
 


### PR DESCRIPTION
scipy.special.ellipeinc uses sqared eccentricity. Thanks for your example in your [blog](https://newbedev.com/how-can-i-generate-a-set-of-points-evenly-distributed-along-the-perimeter-of-an-ellipse), it helped me a lot. When using the example from the blog and calculate the norm of adjacent points

> points = np.array([b * np.sin(phi), a * np.cos(phi)])
> dp = abs(points[:, :-1] - points[:, 1:])
> norm = np.linalg.norm(dp, axis=0)
> maxRelErr =np.max(np.abs(norm / norm[0] - 1)))#, np.abs(norm / norm[0] - 1)
> print(maxRelErr )

for 

> n = 1000

this becomes very apparent. Using e, maxRelErr=0.3658, whereas using eSq, maxRelErr=1.53e-05